### PR TITLE
Change path vertices writable from read only state

### DIFF
--- a/code/scales-projections/text-polar.py
+++ b/code/scales-projections/text-polar.py
@@ -44,6 +44,7 @@ ax.pie(np.ones(12), radius=1, colors=colors, wedgeprops=dict(width=size, edgecol
 # Rotated and transformed label
 def label(text, angle, radius=1, scale=0.005):
     path = TextPath((0, 0), text, size=10)
+    path.vertices.flags.writeable = True
     V = path.vertices
     xmin, xmax = V[:, 0].min(), V[:, 0].max()
     ymin, ymax = V[:, 1].min(), V[:, 1].max()


### PR DESCRIPTION
1. Fix : ValueError: output array is read-only
- Previous code resulted into ValueError: output array is read only at Line No. 50. V -= (xmin + xmax) / 2, (ymin + ymax) / 2
- This is due to default read only access of path vertices in newer (e.g. >= 3.5.1) matplotlib versions
- So we need to change state from read only to write access mode