### PR TITLE
Fixed the height parameter of the "Floating & rotated axis" in Figure 2.9

### DIFF
--- a/code/coordinates/transforms-floating-axis.py
+++ b/code/coordinates/transforms-floating-axis.py
@@ -47,7 +47,7 @@ xmax, ymax = DC_to_NFC((P[:, 0].max(), P[:, 1].max()))
 transform = Affine2D().scale(1, 1).rotate_deg(orientation)
 helper = floating_axes.GridHelperCurveLinear(transform, (0, size[0], 0, size[1]))
 ax2 = floating_axes.FloatingSubplot(fig, 111, grid_helper=helper, zorder=0)
-ax2.set_position((xmin, ymin, xmax - xmin, ymax - xmin))
+ax2.set_position((xmin, ymin, xmax - xmin, ymax - ymin))
 fig.add_subplot(ax2)
 
 

--- a/rst/coordinates.rst
+++ b/rst/coordinates.rst
@@ -315,7 +315,7 @@ We now have all the information to add our new axis:
                  transform, (0, size[0], 0, size[1]))
    ax2 = floating.FloatingSubplot(
                  fig, 111, grid_helper=helper, zorder=0)
-   ax2.set_position((xmin, ymin, xmax-xmin, ymax-xmin))
+   ax2.set_position((xmin, ymin, xmax-xmin, ymax-ymin))
    fig.add_subplot(ax2)
 
 The result is shown on figure :ref:`fig-transforms-floating-axis`.


### PR DESCRIPTION
The height parameter in Figure 2.9 (coordinates/transforms‐floating‐axis.py) as well as the corresponding line of the code in rst/coordinates.rst, were fixed; they should be the differences in Y (ymax-ymin) instead of (ymax-xmin).