### PR TITLE
Update transforms-hist.py

### DIFF
--- a/code/coordinates/transforms-hist.py
+++ b/code/coordinates/transforms-hist.py
@@ -28,10 +28,10 @@ Zm = Z1.mean(axis=0)                              # mean of Z1. Zm = np.array([ 
 # Note that for some seeds, the PC1 and PC2 needs to be inverted
 # It could be fixed by looking at the orientation but I'm lazy
 W, V = np.linalg.eig(np.cov(Z1.T))                 # W: eigenvalues, V: eigenvectors
-PC1, PC2 = V[np.argsort(abs(W))]                   # PC1, PC2: 1st and 2nd Principal components
+PC1, PC2 = V.T[np.flip(np.argsort(abs(W)))]        # PCs are columns of V, and the 1st one has the highest eigenvalue
 if PC2[1] < 0:                                     # to make PC2 "upwards"
     PC2 = -PC2
-rotation = 180 * np.arctan2(*PC1) / np.pi
+rotation = 180 * np.arctan2(*np.flip(PC1)) / np.pi # the 1st argument of arctan2 is the y value
 T = np.array([PC1[0], PC1[1]])                     # tangent vector of PC1 (a deep copy of PC1)
 O = np.array([PC2[0], PC2[1]])                     # orthogonal vector of PC1 (a deep copy of PC2)
 
@@ -110,7 +110,7 @@ h0 = w0 = np.sqrt((xo - x) ** 2 + (yo - y) ** 2)    # preparation of the histogr
 #    It is possible to have non squared axis, but it would complicate things.
 xmin, xmax = -16, 16                               # "enough" large symmetric x limits for histogram
 ymin, ymax = 0, xmax - xmin                        # y limits, same range but positive
-transform = Affine2D().rotate_deg(-rotation)
+transform = Affine2D().rotate_deg(rotation-90)
 helper = floating_axes.GridHelperCurveLinear(transform, (xmin, xmax, ymin, ymax))
 ax2 = floating_axes.FloatingSubplot(fig, 111, grid_helper=helper, zorder=0)
 
@@ -118,7 +118,7 @@ ax2 = floating_axes.FloatingSubplot(fig, 111, grid_helper=helper, zorder=0)
 #    the size and position, it related to the non-rotate axis and we thus need
 #    to compute the bounding box. To do that, we rotate the four coordinates
 #    from which we deduce the bounding box coordinates.
-transform = Affine2D().rotate_deg(-rotation)
+transform = Affine2D().rotate_deg(rotation-90)
 R = transform.transform(                            # outline of the histogram Axes
     [
         (x - w0 / 2, y - h0 / 2),

--- a/code/coordinates/transforms-hist.py
+++ b/code/coordinates/transforms-hist.py
@@ -42,11 +42,11 @@ ax1 = fig.add_axes([0.05, 0.05, 0.9, 0.9], aspect=1)
 
 # Main scatter plot
 ax1.scatter(Z1[:, 0], Z1[:, 1], s=50, fc="C0", ec="white", lw=0.75)
-ax1.set_xlim([-3, 6])
-ax1.set_xticks([-3, 6])
+ax1.set_xlim([-3, 7])
+ax1.set_xticks([-3, 7])
 ax1.set_xticklabels([])
-ax1.set_ylim([-3, 6])
-ax1.set_yticks([-3, 6])
+ax1.set_ylim([-3, 7])
+ax1.set_yticks([-3, 7])
 ax1.set_yticklabels([])
 ax1.spines["top"].set_visible(False)
 ax1.spines["right"].set_visible(False)
@@ -108,7 +108,7 @@ h0 = w0 = np.sqrt((xo - x) ** 2 + (yo - y) ** 2)    # preparation of the histogr
 # 3. Create the secondary axis
 #    Warning: it must be squared, ie. xmax-xmin = ymax-ymin
 #    It is possible to have non squared axis, but it would complicate things.
-xmin, xmax = -16, 16                               # "enough" large symmetric x limits for histogram
+xmin, xmax = -18, 18                               # "enough" large symmetric x limits for histogram
 ymin, ymax = 0, xmax - xmin                        # y limits, same range but positive
 transform = Affine2D().rotate_deg(rotation-90)
 helper = floating_axes.GridHelperCurveLinear(transform, (xmin, xmax, ymin, ymax))
@@ -143,7 +143,7 @@ ax2.set_xticks([0, 1])
 ax2.patch.set_visible(False)
 
 # 6. Display the histogram, taking care of the extents of the X axis
-counts, bins = np.histogram(-Z1 @ PC1, bins=12)     # histogram of -Z1 orthogonal to PC1 direction with 12 bins
+counts, bins = np.histogram(-Z1 @ PC2, bins=12)     # histogram of -Z1 orthogonal to PC1 direction (i.e., scores on PC2) with 12 bins
 X0 = (bins - bins[0]) / (bins[-1] - bins[0])        # X0 : normalized bins range [0, 1]
 X1 = xmin + (xmax - xmin) * X0                      # X1 : stretched bins range [xmin, xmax] = [-16, 16]
 Y = np.array(counts)

--- a/code/coordinates/transforms-hist.py
+++ b/code/coordinates/transforms-hist.py
@@ -164,7 +164,7 @@ for x, y in zip(X1, Y):
         ha="center",
         va="center",
         size=8,
-        rotation=-rotation,
+        rotation=rotation-90,
     )
 
 # Save


### PR DESCRIPTION
The code did not reproduce Fig. 2.7 of the book:
- principal components should be columns of the eigenmatrix;
- rotation should be arctan2(PC1[1], PC1[0]) instead of arctan2(PC1[0], PC1[1]);
- histogram of projections onto PC1 should be rotated by rotation-90 degrees instead of -rotation.