### PR TITLE
Update projection-3d-frame.py

### DIFF
--- a/code/scales-projections/projection-3d-frame.py
+++ b/code/scales-projections/projection-3d-frame.py
@@ -81,12 +81,11 @@ class Arrow3D(mpatches.FancyArrowPatch):
         mpatches.FancyArrowPatch.__init__(self, (0, 0), (0, 0), *args, **kwargs)
         self._verts3d = xs, ys, zs
 
-    def draw(self, renderer):
+    def do_3d_projection(self, renderer=None):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
-        self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
-        mpatches.FancyArrowPatch.draw(self, renderer)
-
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self.set_positions((xs[0],ys[0]),(xs[1],ys[1]))
+        return np.min(zs)
 
 ax.add_artist(
     Arrow3D(


### PR DESCRIPTION
update [code/scales-projections/projection-3d-frame.py](https://github.com/rougier/scientific-visualization-book/blob/master/code/scales-projections/projection-3d-frame.py) to fix the error: `AttributeError: 'Arrow3D' object has no attribute 'do_3d_projection'`

the solution is from [matplotlib issues#21688](https://github.com/matplotlib/matplotlib/issues/21688#issuecomment-974912574)